### PR TITLE
CHECKLIST.md, Corda Testnet documentation improvements.

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -56,6 +56,7 @@ Configuration:
 			- Config fileShareName for node/bridge/float
 			- Config identityManagerAddress and networkmapAddress (without http:// prefix)
 				- You can use any network, but please note that if you want to use Testnet, we will have to skip the initial registration step and download the full Testnet node from the dashboard
+				- Alternative config to above if using Corda Testnet, see Testnet configuration below
 			- Config resourceName to reflect the x500 name of the node, please note to use lowercase letters and numbers only
 			- Config legalName to define the x500 name of the node
 		- Download network root truststore to ./helm/files/network with the name "networkRootTrustStore.jks"
@@ -73,28 +74,29 @@ Configuration:
 			- Please have a look at the logs files for the three pods to make sure they are running without errors (kubectl get pods + kubectl logs -f <pod name>)
 			- Run delete_all.sh to remove all resources from the Kubernetes cluster if you need to start fresh
 
-Testnet configuration:
+Corda Testnet configuration:
 
 	- Retrieve certificates and config:
-      - Register on corda marketplace : https://marketplace.r3.com/register
-      - Go to https://marketplace.r3.com/network/testnet/install-node
-      - Choose 
-        - node version: "Enterprise"
-        - Corda version : 4.0
-      - Click on "Create new node"
-      - Click on download corda node. It should download a `node.zip` file
-    - Update certificates with your keypair:
-      - unzip the `node.zip` on a PC or a VM with internet access. (We are going to call it NODE_DIR)
-      - Edit `node.conf` and change `p2pAddress` 
-      - Run in a shell: `java -jar corda.jar` 
-      - Wait for node to start. That will enrich `certificates/nodekeystore.jks` with the node legal entity key pair
-      - kill the node process
-      - Copy certificates `cp $NODE_DIR/certificates/*.jks ./helm/files/certificates/node`
-    - Values.yaml:
-      - Fill variables  `keystorePassword` and `truststorePassword` from unzipped `node.conf` to  `.Values.corda.firewall.conf.nodeKeystorePassword` and `.Values.corda.firewall.conf.nodeTruststorePassword`
-      - Fill variable `myLegalName` from node.conf to `.Values.corda.node.conf.legalName`
-      - Fill variable `corda.node.conf.compatibilityZoneEnabled`  with `true` in `helm/values.yaml` 
-      - Fill variable `corda.node.conf.compatibilityZoneURL` with `https://netmap.testnet.r3.com`
+		- Register on R3 Corda Marketplace: https://marketplace.r3.com/register
+		- Go to https://marketplace.r3.com/network/testnet/dashboard
+		- Click Create Node: https://marketplace.r3.com/network/testnet/install-node
+		- Choose 
+			- Node version: "Enterprise"
+			- Corda version: 4.0
+		- Click on "Create new node"
+		- Click on "Download Corda Node". A "node.zip" file should be prepared and downloaded
+	- Update certificates with legal entity keys ("identity-private-key" section in "nodekeystore.jks"):
+		- Unzip the "node.zip" to a folder with JVM 1.8 installed and Internet access. (Let's call the full path to download folder NODE_DIR)
+		- Edit "node.conf" and change "p2pAddress" from "0.0.0.0" to "localhost" 
+		- Run in a shell: "java -jar corda.jar"
+		- Wait for node to start. This will enrich "certificates/nodekeystore.jks" with the Nodes legal entity key pair
+		- Kill the node process (ctrl+c)
+		- Copy certificates from Testnet node folder to deployment folder: "cp NODE_DIR/certificates/*.jks ./helm/files/certificates/node"
+	- In "helm/values.yaml":
+		- Copy variables "keystorePassword" and "truststorePassword" from unzipped "node.conf" to sections matching paths ".Values.corda.node.conf.keystorePassword" and ".Values.corda.node.conf.truststorePassword" respectively
+		- Fill variable "myLegalName" from "node.conf" to ".Values.corda.node.conf.legalName"
+		- Fill variable "corda.node.conf.compatibilityZoneEnabled"  with "true"
+		- Fill variable "corda.node.conf.compatibilityZoneURL" with "https://netmap.testnet.r3.com"
 
 
 Useful commands:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ Some people may have moved to a different organisation since their contribution.
 Please forgive any omissions, and create a pull request, or email <henrik.carlstrom@r3.com>, if you wish to see changes to this list.
 
 * Henrik Carlström (R3) - Initial creator
+* Rémi Foult (Natixis) - Lead Blockchain Developer

--- a/corda-pki-generator/pki-firewall/generate_pki.sh
+++ b/corda-pki-generator/pki-firewall/generate_pki.sh
@@ -57,7 +57,6 @@ if [ "$?" -ne "0" ]; then
         fi
     fi
 fi
-set -eux
 
 $KEYTOOL_EXE &>/dev/null
 status=$?
@@ -69,24 +68,42 @@ else
 	exit 1
 fi
 
+set +x
 
-CERTIFICATE_VALIDITY_DAYS=3650
-BRIDGE_PASSWORD=bridgepass
-FLOAT_PASSWORD=floatpass
-TRUST_PASSWORD=trustpass
-CA_PASSWORD=capass
+# Read values.yaml for configuration
+VALUES_YAML=$DIR/../../helm/values.yaml
+FIREWALL_CONF_RAW=$(grep -A 14 ' firewall:' $VALUES_YAML) # Find configuration path .Values.corda.firewall.conf
+echo "Reading values.yaml file ($VALUES_YAML), contents: $FIREWALL_CONF_RAW"
+CERTIFICATE_VALIDITY_DAYS=$(echo "$FIREWALL_CONF_RAW" | grep 'certificateValidityInDays: "' | cut -d '"' -f 2)
+TRUST_PASSWORD=$(echo "$FIREWALL_CONF_RAW" | grep 'truststorePassword: "' | cut -d '"' -f 2)
+BRIDGE_PASSWORD=$(echo "$FIREWALL_CONF_RAW" | grep 'bridgeKeystorePassword: "' | cut -d '"' -f 2)
+FLOAT_PASSWORD=$(echo "$FIREWALL_CONF_RAW" | grep 'floatKeystorePassword: "' | cut -d '"' -f 2)
+CA_KEYSTORE_PASSWORD=$(echo "$FIREWALL_CONF_RAW" | grep 'keystorePasswordCA: "' | cut -d '"' -f 2)
+CA_KEY_PASSWORD=$(echo "$FIREWALL_CONF_RAW" | grep 'keyPasswordCA: "' | cut -d '"' -f 2)
 
-$KEYTOOL_EXE -genkeypair -keyalg EC -keysize 256 -alias firewallroot -validity $CERTIFICATE_VALIDITY_DAYS -dname "CN=Firewall Root,O=Local Only,L=London,C=GB" -ext bc:ca:true,pathlen:1 -keystore $WORKDIR/firewallca.jks -storepass $CA_PASSWORD -keypass cakeypass
+set -eux
+
+if [ "$CERTIFICATE_VALIDITY_DAYS" == "" -o "$TRUST_PASSWORD" == "" -o "$BRIDGE_PASSWORD" == "" -o "$FLOAT_PASSWORD" == "" -o "$CA_KEYSTORE_PASSWORD" == "" -o "$CA_KEY_PASSWORD" == "" ]; then
+	echo "Some values were not set correctly from values.yaml file, please check the following values in the values.yaml file:"
+	echo "CERTIFICATE_VALIDITY_DAYS=$CERTIFICATE_VALIDITY_DAYS"
+	echo "TRUST_PASSWORD=$TRUST_PASSWORD"
+	echo "BRIDGE_PASSWORD=$BRIDGE_PASSWORD"
+	echo "FLOAT_PASSWORD=$FLOAT_PASSWORD"
+	echo "CA_KEYSTORE_PASSWORD=$CA_KEYSTORE_PASSWORD"
+	echo "CA_KEY_PASSWORD=$CA_KEY_PASSWORD"
+fi
+
+$KEYTOOL_EXE -genkeypair -keyalg EC -keysize 256 -alias firewallroot -validity $CERTIFICATE_VALIDITY_DAYS -dname "CN=Firewall Root,O=Local Only,L=London,C=GB" -ext bc:ca:true,pathlen:1 -keystore $WORKDIR/firewallca.jks -storepass $CA_KEYSTORE_PASSWORD -keypass $CA_KEY_PASSWORD
 $KEYTOOL_EXE -genkeypair -keyalg EC -keysize 256 -alias bridgecert -validity $CERTIFICATE_VALIDITY_DAYS -dname "CN=Bridge Local,O=Local Only,L=London,C=GB" -ext bc:ca:false -keystore $WORKDIR/bridge.jks -storepass $BRIDGE_PASSWORD -keypass $BRIDGE_PASSWORD
 $KEYTOOL_EXE -genkeypair -keyalg EC -keysize 256 -alias floatcert -validity $CERTIFICATE_VALIDITY_DAYS -dname "CN=Float Local,O=Local Only,L=London,C=GB" -ext bc:ca:false -keystore $WORKDIR/float.jks -storepass $FLOAT_PASSWORD -keypass $FLOAT_PASSWORD
 
-$KEYTOOL_EXE -exportcert -rfc -alias firewallroot -keystore $WORKDIR/firewallca.jks -storepass $CA_PASSWORD -keypass cakeypass > $WORKDIR/root.pem
+$KEYTOOL_EXE -exportcert -rfc -alias firewallroot -keystore $WORKDIR/firewallca.jks -storepass $CA_KEYSTORE_PASSWORD -keypass $CA_KEY_PASSWORD > $WORKDIR/root.pem
 $KEYTOOL_EXE -importcert -noprompt -file $WORKDIR/root.pem -alias root -keystore $WORKDIR/trust.jks -storepass $TRUST_PASSWORD
 
-$KEYTOOL_EXE -certreq -alias bridgecert -keystore $WORKDIR/bridge.jks -storepass $BRIDGE_PASSWORD -keypass $BRIDGE_PASSWORD | $KEYTOOL_EXE -gencert -ext ku:c=dig,keyEncipherment -ext: eku:true=serverAuth,clientAuth -rfc -keystore $WORKDIR/firewallca.jks -alias firewallroot -validity $CERTIFICATE_VALIDITY_DAYS -storepass $CA_PASSWORD -keypass cakeypass > $WORKDIR/bridge.pem
+$KEYTOOL_EXE -certreq -alias bridgecert -keystore $WORKDIR/bridge.jks -storepass $BRIDGE_PASSWORD -keypass $BRIDGE_PASSWORD | $KEYTOOL_EXE -gencert -ext ku:c=dig,keyEncipherment -ext: eku:true=serverAuth,clientAuth -rfc -keystore $WORKDIR/firewallca.jks -alias firewallroot -validity $CERTIFICATE_VALIDITY_DAYS -storepass $CA_KEYSTORE_PASSWORD -keypass $CA_KEY_PASSWORD > $WORKDIR/bridge.pem
 cat $WORKDIR/root.pem $WORKDIR/bridge.pem >> $WORKDIR/bridgechain.pem
 $KEYTOOL_EXE -importcert -noprompt -file $WORKDIR/bridgechain.pem -alias bridgecert -keystore $WORKDIR/bridge.jks -storepass $BRIDGE_PASSWORD -keypass $BRIDGE_PASSWORD
 
-$KEYTOOL_EXE -certreq -alias floatcert -keystore $WORKDIR/float.jks -storepass $FLOAT_PASSWORD -keypass $FLOAT_PASSWORD | $KEYTOOL_EXE -gencert -ext ku:c=dig,keyEncipherment -ext: eku::true=serverAuth,clientAuth -rfc -keystore $WORKDIR/firewallca.jks -alias firewallroot -validity $CERTIFICATE_VALIDITY_DAYS -storepass $CA_PASSWORD -keypass cakeypass > $WORKDIR/float.pem
+$KEYTOOL_EXE -certreq -alias floatcert -keystore $WORKDIR/float.jks -storepass $FLOAT_PASSWORD -keypass $FLOAT_PASSWORD | $KEYTOOL_EXE -gencert -ext ku:c=dig,keyEncipherment -ext: eku::true=serverAuth,clientAuth -rfc -keystore $WORKDIR/firewallca.jks -alias firewallroot -validity $CERTIFICATE_VALIDITY_DAYS -storepass $CA_KEYSTORE_PASSWORD -keypass $CA_KEY_PASSWORD > $WORKDIR/float.pem
 cat $WORKDIR/root.pem $WORKDIR/float.pem >> $WORKDIR/floatchain.pem
 $KEYTOOL_EXE -importcert -noprompt -file $WORKDIR/floatchain.pem -alias floatcert -keystore $WORKDIR/float.jks -storepass $FLOAT_PASSWORD -keypass $FLOAT_PASSWORD

--- a/helm/files/bridge.conf
+++ b/helm/files/bridge.conf
@@ -11,7 +11,7 @@ bridgeInnerConfig: {
   floatAddresses: [ "{{- if ne .Values.corda.node.conf.floatInternalAddress "" }}
 	{{- .Values.corda.node.conf.floatInternalAddress }}
 {{- else }}
-	{{- if and .Values.setup.firewall.enabled .Values.setup.firewall.destination.internalKubernetesCluster.enabled }}
+	{{- if and .Values.setup.cordaFirewall.enabled .Values.setup.cordaFirewall.destination.internalKubernetesCluster.enabled }}
 		{{- .Values.config.resourceName }}-float-service
 	{{- else }}
 		{{- .Values.corda.node.conf.p2pAddress }}
@@ -30,8 +30,8 @@ bridgeInnerConfig: {
 certificatesDirectory: "./workspace/certificates"
 sslKeystore: "./workspace/certificates/sslkeystore.jks"
 trustStoreFile: "./workspace/certificates/truststore.jks"
-keyStorePassword: "{{ .Values.corda.firewall.conf.nodeKeystorePassword }}"
-trustStorePassword: "{{ .Values.corda.firewall.conf.nodeTruststorePassword }}"
+keyStorePassword: "{{ .Values.corda.node.conf.keystorePassword }}"
+trustStorePassword: "{{ .Values.corda.node.conf.truststorePassword }}"
 crlCheckSoftFail: {{ .Values.corda.node.conf.crlCheckSoftFail }}
 silencedIPs: []
 

--- a/helm/files/node.conf
+++ b/helm/files/node.conf
@@ -46,8 +46,8 @@ dataSourceProperties: {
   dataSource.user: "{{ .Values.corda.node.conf.dataSource.user }}",
   dataSource.password: "{{ .Values.corda.node.conf.dataSource.password }}"
 }
-trustStorePassword: "{{ .Values.corda.firewall.conf.nodeTruststorePassword }}"
-keyStorePassword : "{{ .Values.corda.firewall.conf.nodeKeystorePassword }}"
+trustStorePassword: "{{ .Values.corda.node.conf.truststorePassword }}"
+keyStorePassword : "{{ .Values.corda.node.conf.keystorePassword }}"
 detectPublicIp: false
 messagingServerAddress: "0.0.0.0:{{ .Values.corda.node.conf.p2pPort }}"
 messagingServerExternal: false

--- a/helm/templates/deployment-CordaFloat.yml
+++ b/helm/templates/deployment-CordaFloat.yml
@@ -1,10 +1,10 @@
-{{- if .Values.setup.firewall.destination.internalKubernetesCluster.enabled }}
+{{- if .Values.setup.cordaFirewall.destination.internalKubernetesCluster.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Values.config.resourceName }}-float-service
 spec:
-{{- if and .Values.setup.firewall.enabled .Values.setup.firewall.destination.internalKubernetesCluster.enabled }}
+{{- if and .Values.setup.cordaFirewall.enabled .Values.setup.cordaFirewall.destination.internalKubernetesCluster.enabled }}
   loadBalancerIP: "{{ .Values.config.floatLoadBalancerIP }}"
   type: LoadBalancer
 {{- end }}

--- a/helm/templates/volume-CordaFloat.yml
+++ b/helm/templates/volume-CordaFloat.yml
@@ -1,4 +1,4 @@
-{{- if .Values.setup.firewall.destination.internalKubernetesCluster.enabled }}
+{{- if .Values.setup.cordaFirewall.destination.internalKubernetesCluster.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,8 +7,8 @@ setup:
   initialRegistration:
     # enabled is a boolean value for the above parameter
     enabled: true
-  # firewall defines if we should activate the Corda Firewall component as part of the installation or not
-  firewall:
+  # cordaFirewall defines if we should activate the Corda Firewall component as part of the installation or not
+  cordaFirewall:
     # enabled is a boolean value for the above parameter
     enabled: true
     # destination defines where the Float will be deployed
@@ -130,8 +130,12 @@ corda:
       # compatibilityZoneEnabled defines if you are connecting to a compatibility zone rather than using the above identityManagerAddress+networkmapAddress. Set this to true to be able to join Corda Testnet along with compatibilityZoneURL.
       compatibilityZoneEnabled: false
       # compatibilityZoneURL defines the root address of Corda compatibility zone network management services. For Corda Testnet you can use "https://netmap.testnet.r3.com"
-      compatibilityZoneURL: "" # Exemple for testnet "https://netmap.testnet.r3.com"     
-      # truststorePassword defines the password with which to unlock the network root truststore file usually named 'networkRootTrustStore.jks'.
+      compatibilityZoneURL: ""
+      # networkRootTruststorePassword defines the password with which to unlock the network root truststore file usually named 'networkRootTrustStore.jks'.
+      networkRootTruststorePassword: "trustpass"
+      # keystorePassword defines the password with which to unlock the Node keystore file, usually named "nodekeystore.jks". This value will also end up in the "bridge.conf" file
+      keystorePassword: "cordacadevpass"
+      # truststorePassword defines the password with which to unlock the Node truststore file, usually named "truststore.jks". This value will also end up in the "bridge.conf" file
       truststorePassword: "trustpass"
       # crlCheckSoftFail defines if CRL failure is a critical error or if we can just fail softly (by logging an error) and continuing
       crlCheckSoftFail: true
@@ -185,14 +189,16 @@ corda:
   firewall: 
     # Values that will end up in the bridge.conf/float.conf files
     conf: 
-      # truststorePassword defines the password with which to unlock the firewall tunnel root truststore file usually named 'trust.jks'.
-      truststorePassword: "trustpass" # NOTE! The link to corda-pki-generator/pki-firewall/generate_pki.sh is not automated yet, if you change this parameter you would have to manually edit the "sh" file as well.
-      # truststorePassword defines the password with which to unlock the firewall tunnel root truststore file usually named 'trust.jks'.
-      bridgeKeystorePassword: "bridgepass" # NOTE! The link to corda-pki-generator/pki-firewall/generate_pki.sh is not automated yet, if you change this parameter you would have to manually edit the "sh" file as well.
-      # truststorePassword defines the password with which to unlock the firewall tunnel root truststore file usually named 'trust.jks'.
-      floatKeystorePassword: "floatpass" # NOTE! The link to corda-pki-generator/pki-firewall/generate_pki.sh is not automated yet, if you change this parameter you would have to manually edit the "sh" file as well.
-      # Value that will end up in the node.conf/bridge.conf
-      nodeKeystorePassword: "cordacadevpass"
-      # Value that will end up in the node.conf/bridge.conf
-      nodeTruststorePassword: "trustpass"
+      # certificateValidityInDays defines how long the tunnel certificates will be valid for, in days
+      certificateValidityInDays: "3650"
+      # truststorePassword defines the password with which to unlock the firewall tunnel root truststore file usually named "trust.jks".
+      truststorePassword: "trustpass"
+      # truststorePassword defines the password with which to unlock the firewall tunnel root truststore file usually named "trust.jks".
+      bridgeKeystorePassword: "bridgepass"
+      # truststorePassword defines the password with which to unlock the firewall tunnel root truststore file usually named "trust.jks".
+      floatKeystorePassword: "floatpass"
+      # keystorePasswordCA defines the password for the tunnel certificates root CA
+      keystorePasswordCA: "capass"
+      # keyPasswordCA defines the password for the tunnel certificates root CA key
+      keyPasswordCA: "cakeypass"
 # fin.


### PR DESCRIPTION
CONTRIBUTORS.md, added Rémi Foult
generate_pki.sh, now fetches the required configuration values from values.yaml.
values.yaml, renamed firewall configuration section to cordaFirewall to distinguish it from firewall section in corda conf section.
Also moved keystorePassword and truststorePassword from firewall section to node section.

(cherry picked from commit c19fa3869daa23a38c4271a726da5e2f19f9f564)